### PR TITLE
Sudo U2F Support (#26)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/.github/** @TAP-lab/securityManagers
+**/security/** @TAP-lab/securityManagers

--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@ This NixOS configuration is made to be used with the TAP-lab laptops, with all o
 
 # Table of Contents
 
+- [Taplab NixOS Config](#taplab-nixos-config)
+- [Table of Contents](#table-of-contents)
 - [Quick Start Guide](#quick-start-guide)
 - [Usage Guide](#usage-guide)
 - [Full Instructions](#full-instructions)
+      - [In case of any issues, please Contact Callum (clamlum2@gmail.com).](#in-case-of-any-issues-please-contact-callum-clamlum2gmailcom)
 - [Rebuild Script](#rebuild-script)
 
 
@@ -39,6 +42,8 @@ This NixOS configuration is made to be used with the TAP-lab laptops, with all o
 - The system has 3 network shares automatically mounted, manuhiri, Hacklings , and mema. The first 2 should mount automatically provided the laptop is on the TAP-lab network. The mema share requires credentials to access, which can be pulled from the local server by running the `mema` command in terminal.
 
 - There is a script to automatically set up Microsoft Edge to log in to the TAP-lab account. This can be run by executing the `edge` command in terminal. This also requires the laptop to be on the TAP-lab network.
+
+- **U2F Authentication**: The system supports U2F security keys for sudo authentication. U2F keys are managed directly in this repo at `resources/security/u2f_keys` and installed to `/etc/Yubico/u2f_keys` during rebuild. If the U2F key is not present, the system will fall back to password authentication.
 
 
 # Full Instructions

--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -56,4 +56,26 @@
   };
 
   services.printing.enable = true;
+
+  # Enable the U2F PAM module and set the key file. Make U2F optional with a fallback to password.
+  security.pam.u2f = {
+    enable = true;
+    control = "sufficient";
+    authFile = "/etc/Yubico/u2f_keys";
+  };
+
+  # Copy the U2F key file to the appropriate location with correct permissions.
+  environment.etc."Yubico/u2f_keys" = {
+    source = ../resources/security/u2f_keys;
+    user = "root";
+    group = "root";
+    mode = "0600";
+  };
+
+  # Enable U2F and set up cue
+  security.pam.services.sudo.u2fAuth = true;
+  security.pam.u2f.settings.cue = true;
+  environment.systemPackages = with pkgs; [
+    pam_u2f
+  ];
 }

--- a/resources/security/u2f_keys
+++ b/resources/security/u2f_keys
@@ -6,12 +6,11 @@
 # Generate entries with:
 #   pamu2fcfg -u <username>
 
+# Alex YK 35 05 300
+taplab:spMUBfmDpXfJCdt51Fz7JzzDr5wPkGIsbvzNz27pAAIdrOEEDvRL6t0Yixt5TtBRyJNPZL72LFEvh+JnPTJwVQ==,SET63p8SFVAbn5eBSE2OyhtTEjxNm2Ih/hi/HQV4wMQpl2T0nEuXKQw+WArY2xNG9dSYBKj0rLisK0VeIb+p/A==,es256,+presence
 
-# Alex Yubikey 35 045 300
+# COW YK 35 045 221
+taplab:6rWV6JPYCF+b3cH9dqAy6WHdS2i/bj1gRhTt/oXMAEX8YP83IFt0HU6ZnzvK92sqYcWl63ahxwfsk6J7EgkJ4w==,zjEzzdOODYetTWdX9/LK01Z3W4KSC916dXNjEBGUcdabTOJVi2wZBLT/Mc8g9I2E6R/fYVIMZWTKhHDFrlNzaw==,es256,+presence
 
-
-# COW Yubikey
-
-
-# Cage Yubikey
-
+# Cage YK 35 045 479
+taplab:bKER6N+Y0NQX0MlYKxd1upcVduuJ+lEjc1AocT62QRIZY2S3tIHomimk8ggDyUBX5g1pOVbMBHL+DFW7ILFtoA==,C815XDY3u35+ioYy41eOm8usAxdUi9xuMmn210cqvHWIn08z4JmyaFjJqGSliB0cSTtfHl2hmpH++VrKgff8Ww==,es256,+presence

--- a/resources/security/u2f_keys
+++ b/resources/security/u2f_keys
@@ -1,0 +1,17 @@
+# pam_u2f key mappings for sudo
+#
+# One user per line, format:
+#   <username>:<KeyHandle1>,<UserKey1>[,<COSEType1>,<Options1>][:<KeyHandle2>,...]
+#
+# Generate entries with:
+#   pamu2fcfg -u <username>
+
+
+# Alex Yubikey 35 045 300
+
+
+# COW Yubikey
+
+
+# Cage Yubikey
+


### PR DESCRIPTION
Begin adding U2F support to allow elevating to sudo via yubikeys instead of a password.

This request sets the initial groundwork and introduces a codeowner file that will require a reviewer for all changes that modify the valid U2F keys.

Adding the initial yubikeys is still to be done before this can be merged. 

Tested on a dev machine without issues.

* Initial U2F setup

* Add shell alias

* Migrate to system wide u2f file

* Swap U2F to declaritive

* Protect U2F configuration with codeowners

* Potential fix for pull request finding

* Potential fix for pull request finding

* Move U2F Configs to end of configuration.nix to reduce merge conflicts. Add comments

* Tidy u2f_keys file